### PR TITLE
Remove hardcoded references to user

### DIFF
--- a/app/views/devise/verification/new.erb
+++ b/app/views/devise/verification/new.erb
@@ -1,6 +1,6 @@
 <h2>Account Verification</h2>
 
-<%= form_for(resource, as: resource_name, url: user_verification_path, method: :post) do |f| %>
+<%= form_for(resource, as: resource_name, url: verification_path(resource_name), method: :post) do |f| %>
 
   <%= devise_error_messages! %>
 

--- a/lib/devise-verifiable.rb
+++ b/lib/devise-verifiable.rb
@@ -17,4 +17,4 @@ end
 
 Devise.add_module :verifiable, model: 'devise/models/verifiable',
                                controller: :verifications,
-                               route: { verification: [:new, :create] }
+                               route: { verification: [nil, :new, :create] }

--- a/lib/devise/controller/helpers.rb
+++ b/lib/devise/controller/helpers.rb
@@ -11,7 +11,7 @@ module Devise
 
             def authenticate_verified_#{mapping}!(opts={})
               authenticate_#{mapping}!
-              redirect_to new_user_verification_path unless current_#{mapping}.verified?
+              redirect_to new_#{mapping}_verification_path unless current_#{mapping}.verified?
             end
 
           METHODS


### PR DESCRIPTION
Hi @Rodrigora!

Thanks so much for this super-great gem. We've run into a limitation, which is that there are a couple hardcoded references to user, both in the default view and in the URL helper generation. 

We've got an app that doesn't contain a User model, so this pull request lets us loosen up that restriction.

Thank you!